### PR TITLE
frontend: fix repeat and default playback

### DIFF
--- a/frontend/src/app/play/[id]/page.tsx
+++ b/frontend/src/app/play/[id]/page.tsx
@@ -21,7 +21,7 @@ export default function PlaySongPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [isPlaying, setIsPlaying] = useState(false);
   const [isShuffle, setIsShuffle] = useState(false);
-  const [repeatMode, setRepeatMode] = useState<'none' | 'all' | 'one'>('none');
+  const [repeatMode, setRepeatMode] = useState<'none' | 'all' | 'one'>('all');
   const [isMuted, setIsMuted] = useState(false);
   const [isLiked, setIsLiked] = useState(false);
   const [volume, setVolume] = useState(75);

--- a/frontend/src/lib/playlist-manager.ts
+++ b/frontend/src/lib/playlist-manager.ts
@@ -102,15 +102,14 @@ export class PlaylistManager {
   }
   
   // 切换到下一首歌
-  static getNextSong(shuffleMode: boolean = false, repeatMode: 'none' | 'all' | 'one' = 'none'): Song | null {
+  static getNextSong(
+    shuffleMode: boolean = false,
+    repeatMode: 'none' | 'all' | 'one' = 'all'
+  ): Song | null {
     const playlist = this.getCurrentPlaylist();
     if (!playlist || playlist.songs.length === 0) return null;
     
     const { songs, currentIndex } = playlist;
-    
-    if (repeatMode === 'one') {
-      return songs[currentIndex] || null;
-    }
     
     let nextIndex: number;
     
@@ -199,11 +198,13 @@ export class PlaylistManager {
   }
   
   // 检查是否可以播放下一首
-  static canPlayNext(repeatMode: 'none' | 'all' | 'one' = 'none'): boolean {
+  static canPlayNext(
+    repeatMode: 'none' | 'all' | 'one' = 'all'
+  ): boolean {
     const playlist = this.getCurrentPlaylist();
     if (!playlist || playlist.songs.length === 0) return false;
-    
-    if (repeatMode === 'one' || repeatMode === 'all') return true;
+
+    if (repeatMode === 'all') return true;
     
     return playlist.currentIndex < playlist.songs.length - 1;
   }

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -65,7 +65,7 @@ export const usePlayerStore = create<PlayerStore>()(
       duration: 0,
       playlist: [],
       currentIndex: -1,
-      repeatMode: 'none',
+      repeatMode: 'all',
       shuffleMode: false,
       currentPlaylist: null,
       playbackMode: 'song',


### PR DESCRIPTION
## Summary
- Default to playlist looping when no repeat mode specified
- Ensure manual next works in single-repeat mode and wrap logic uses repeat-all
- Align PlaySongPage with new default repeat behavior

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_68a3e48f597c8332b8831c3e1cd3d1c5