### PR TITLE
Fix repeat playback modes

### DIFF
--- a/frontend/src/components/audio-manager.tsx
+++ b/frontend/src/components/audio-manager.tsx
@@ -141,14 +141,14 @@ export function AudioManager() {
         cancelAnimationFrame(timeUpdateRef.current);
         timeUpdateRef.current = null;
       }
-      
-      if (repeatMode === 'one') {
-        // 单曲循环：重新播放当前歌曲
-        audio.currentTime = 0;
-        audio.play().catch(console.error);
-      } else {
-        // 其他情况（列表播放、随机播放、列表循环）：让 nextSong 函数处理
-        nextSong();
+
+      switch (repeatMode) {
+        case 'one':
+          audio.currentTime = 0;
+          audio.play().catch(console.error);
+          break;
+        default:
+          nextSong();
       }
     };
 
@@ -186,7 +186,7 @@ export function AudioManager() {
       audio.removeEventListener('error', handleError);
       audio.removeEventListener('seeked', handleSeeked);
     };
-  }, [setCurrentTime, setDuration, pause, nextSong, currentSong, recordPlay]);  // 添加currentSong和recordPlay依赖
+  }, [setCurrentTime, setDuration, pause, nextSong, currentSong, recordPlay, repeatMode]); // ensure repeat mode updates
 
   // 处理歌曲切换
   useEffect(() => {

--- a/frontend/src/lib/playlist-manager.ts
+++ b/frontend/src/lib/playlist-manager.ts
@@ -102,34 +102,46 @@ export class PlaylistManager {
   }
   
   // 切换到下一首歌
-  static getNextSong(shuffleMode: boolean = false, repeatMode: 'none' | 'all' | 'one' = 'none'): Song | null {
+  static getNextSong(
+    shuffleMode: boolean = false,
+    repeatMode: 'none' | 'all' | 'one' = 'none'
+  ): Song | null {
     const playlist = this.getCurrentPlaylist();
     if (!playlist || playlist.songs.length === 0) return null;
-    
+
+    const mode = repeatMode ?? 'none';
     const { songs, currentIndex } = playlist;
-    
-    if (repeatMode === 'one') {
+
+    // 单曲循环直接返回当前歌曲
+    if (mode === 'one') {
       return songs[currentIndex] || null;
     }
-    
-    let nextIndex: number;
-    
+
+    let nextIndex = currentIndex;
+
     if (shuffleMode) {
       // 随机播放：选择一个不同的随机歌曲
-      const availableIndices = songs.map((_, i) => i).filter(i => i !== currentIndex);
-      if (availableIndices.length === 0) return songs[currentIndex] || null;
-      nextIndex = availableIndices[Math.floor(Math.random() * availableIndices.length)];
+      const available = songs.map((_, i) => i).filter(i => i !== currentIndex);
+      if (available.length === 0) {
+        if (mode === 'all') {
+          nextIndex = currentIndex;
+        } else {
+          return null;
+        }
+      } else {
+        nextIndex = available[Math.floor(Math.random() * available.length)];
+      }
     } else {
       nextIndex = currentIndex + 1;
       if (nextIndex >= songs.length) {
-        if (repeatMode === 'all') {
+        if (mode === 'all') {
           nextIndex = 0;
         } else {
           return null; // 播放列表结束
         }
       }
     }
-    
+
     const nextSong = songs[nextIndex];
     if (nextSong) {
       const updatedPlaylist = {
@@ -140,7 +152,7 @@ export class PlaylistManager {
       };
       this.saveCurrentPlaylist(updatedPlaylist);
     }
-    
+
     return nextSong;
   }
   
@@ -202,9 +214,10 @@ export class PlaylistManager {
   static canPlayNext(repeatMode: 'none' | 'all' | 'one' = 'none'): boolean {
     const playlist = this.getCurrentPlaylist();
     if (!playlist || playlist.songs.length === 0) return false;
-    
-    if (repeatMode === 'one' || repeatMode === 'all') return true;
-    
+
+    const mode = repeatMode ?? 'none';
+    if (mode === 'one' || mode === 'all') return true;
+
     return playlist.currentIndex < playlist.songs.length - 1;
   }
   


### PR DESCRIPTION
## Summary
- ensure audio repeat mode updates immediately and handle ended event via switch
- rework playlist manager's next-song logic for 'one', 'all', and default play-once modes

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68a3e48f597c8332b8831c3e1cd3d1c5