### PR TITLE
frontend: rethrow fetch errors in service worker

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -132,6 +132,7 @@ async function staleWhileRevalidate(request, cacheName, maxAge = null) {
     return response;
   }).catch(error => {
     console.log('Background fetch failed:', request.url, error);
+    throw error;
   });
   
   // Return cached version if available and not too old


### PR DESCRIPTION
## Summary
- ensure service worker rethrows background fetch errors so offline fallback works

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68a53da591d08332b7847c211d48d879