### PR TITLE
feat: add time-aligned multi-device listening rooms

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import StreamingResponse, JSONResponse
 from pydantic import BaseModel
 from typing import List, Optional, Dict, Any
+from threading import Lock
 import sqlite3
 import json
 import jwt
@@ -44,6 +45,9 @@ app.add_middleware(
 
 # Include user routes (no authentication required)
 app.include_router(user_router)
+
+sync_rooms: Dict[str, Dict[str, Any]] = {}
+sync_rooms_lock = Lock()
 
 # Database Models
 class Artist(BaseModel):
@@ -200,6 +204,23 @@ class CheckExistsRequest(BaseModel):
 
 class PlaylistReorder(BaseModel):
     songIds: List[str]
+
+
+class SyncRoomCreateRequest(BaseModel):
+    hostName: str = "Host"
+
+
+class SyncRoomJoinRequest(BaseModel):
+    userName: str = "Guest"
+
+
+class SyncRoomActionRequest(BaseModel):
+    actor: str = "anonymous"
+    isPlaying: bool
+    currentTime: float
+    songId: Optional[str] = None
+    executeAtMs: int
+    version: int
 
 # Music Moments models
 class MomentComment(BaseModel):
@@ -1844,6 +1865,73 @@ async def delete_comment(moment_id: str, comment_id: str, user: dict = Depends(v
         raise HTTPException(status_code=500, detail=str(e))
     finally:
         conn.close()
+
+@app.get("/api/sync/time")
+async def get_sync_time():
+    return {"serverTimeMs": int(datetime.utcnow().timestamp() * 1000)}
+
+@app.post("/api/sync/rooms")
+async def create_sync_room(payload: SyncRoomCreateRequest):
+    room_id = uuid.uuid4().hex[:8]
+    now_ms = int(datetime.utcnow().timestamp() * 1000)
+    room = {
+        "id": room_id,
+        "hostName": payload.hostName,
+        "members": [payload.hostName],
+        "state": {
+            "isPlaying": False,
+            "currentTime": 0,
+            "songId": None,
+            "executeAtMs": now_ms + 2000,
+            "version": 1,
+            "updatedAtMs": now_ms,
+            "actor": payload.hostName
+        }
+    }
+    with sync_rooms_lock:
+        sync_rooms[room_id] = room
+    return room
+
+@app.post("/api/sync/rooms/{room_id}/join")
+async def join_sync_room(room_id: str, payload: SyncRoomJoinRequest):
+    with sync_rooms_lock:
+        room = sync_rooms.get(room_id)
+        if not room:
+            raise HTTPException(status_code=404, detail="Room not found")
+        if payload.userName not in room["members"]:
+            room["members"].append(payload.userName)
+        return room
+
+@app.get("/api/sync/rooms/{room_id}")
+async def get_sync_room(room_id: str):
+    with sync_rooms_lock:
+        room = sync_rooms.get(room_id)
+        if not room:
+            raise HTTPException(status_code=404, detail="Room not found")
+        return room
+
+@app.post("/api/sync/rooms/{room_id}/action")
+async def update_sync_action(room_id: str, payload: SyncRoomActionRequest):
+    now_ms = int(datetime.utcnow().timestamp() * 1000)
+    with sync_rooms_lock:
+        room = sync_rooms.get(room_id)
+        if not room:
+            raise HTTPException(status_code=404, detail="Room not found")
+
+        current_version = room["state"]["version"]
+        if payload.version < current_version:
+            raise HTTPException(status_code=409, detail="Room state is outdated")
+
+        room["state"] = {
+            "isPlaying": payload.isPlaying,
+            "currentTime": payload.currentTime,
+            "songId": payload.songId,
+            "executeAtMs": payload.executeAtMs,
+            "version": current_version + 1,
+            "updatedAtMs": now_ms,
+            "actor": payload.actor
+        }
+        return room
 
 init_db()
 if __name__ == "__main__":

--- a/frontend/src/app/play/play-client.tsx
+++ b/frontend/src/app/play/play-client.tsx
@@ -67,8 +67,14 @@ export default function PlayClient() {
   const [isMomentVisible, setIsMomentVisible] = useState(true);
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [syncName, setSyncName] = useState('listener');
+  const [syncRoomId, setSyncRoomId] = useState('');
+  const [syncVersion, setSyncVersion] = useState(1);
+  const [clockOffsetMs, setClockOffsetMs] = useState(0);
+  const [syncInfo, setSyncInfo] = useState('未加入房间');
   const searchParams = useSearchParams();
   const handledParamsRef = useRef(false);
+  const latestAppliedVersionRef = useRef(0);
 
   // 初始化播放列表 - 新用户或没有播放列表时自动加载推荐列表
   useEffect(() => {
@@ -326,6 +332,81 @@ export default function PlayClient() {
 
   const displayLyrics = currentSong ? currentLyrics : defaultLyrics;
 
+  const syncClock = async () => {
+    const start = Date.now();
+    const res = await api.getSyncTime();
+    const end = Date.now();
+    if (res.success && res.data) {
+      const rtt = end - start;
+      const approxServerNow = res.data.serverTimeMs + Math.floor(rtt / 2);
+      setClockOffsetMs(approxServerNow - end);
+    }
+  };
+
+  const createRoom = async () => {
+    await syncClock();
+    const res = await api.createSyncRoom(syncName);
+    if (res.success && res.data) {
+      setSyncRoomId(res.data.id);
+      setSyncVersion(res.data.state.version);
+      setSyncInfo(`房间已创建：${res.data.id}`);
+    }
+  };
+
+  const joinRoom = async () => {
+    await syncClock();
+    const res = await api.joinSyncRoom(syncRoomId, syncName);
+    if (res.success && res.data) {
+      setSyncVersion(res.data.state.version);
+      setSyncInfo(`已加入房间：${syncRoomId}`);
+    }
+  };
+
+  const broadcastState = async (targetPlaying: boolean) => {
+    if (!syncRoomId) return;
+    const executeAtMs = Date.now() + clockOffsetMs + 1200;
+    const res = await api.updateSyncRoomAction(syncRoomId, {
+      actor: syncName,
+      isPlaying: targetPlaying,
+      currentTime,
+      songId: currentSong?.id || null,
+      executeAtMs,
+      version: syncVersion,
+    });
+    if (res.success && res.data) {
+      setSyncVersion(res.data.state.version);
+      setSyncInfo(`已广播 ${targetPlaying ? '播放' : '暂停'} 指令`);
+    }
+  };
+
+  useEffect(() => {
+    if (!syncRoomId) return;
+    const timer = setInterval(async () => {
+      const res = await api.getSyncRoom(syncRoomId);
+      if (!res.success || !res.data) return;
+      const room = res.data;
+      setSyncVersion(room.state.version);
+      if (room.state.version <= latestAppliedVersionRef.current) return;
+      latestAppliedVersionRef.current = room.state.version;
+      const delay = Math.max(0, room.state.executeAtMs - (Date.now() + clockOffsetMs));
+      window.setTimeout(async () => {
+        if (room.state.songId && room.state.songId !== currentSong?.id) {
+          const songRes = await api.getSong(room.state.songId);
+          if (songRes.success && songRes.data) {
+            setSong(songRes.data);
+          }
+        }
+        seekTo(room.state.currentTime);
+        if (room.state.isPlaying) {
+          play();
+        } else {
+          pause();
+        }
+      }, delay);
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [syncRoomId, currentSong?.id, clockOffsetMs, pause, play, seekTo, setSong]);
+
   return (
     <div className="h-full bg-background relative lg:flex lg:overflow-hidden">
       {/* Dynamic Ambient Glow Background */}
@@ -344,6 +425,21 @@ export default function PlayClient() {
         {/* Theme Toggle */}
         <div className="absolute top-4 right-4 z-30">
           <ThemeToggle />
+        </div>
+        <div className="absolute top-4 left-4 z-30 bg-background/80 backdrop-blur rounded-md p-2 text-xs space-y-2 w-64">
+          <div className="font-medium">一起听（时间对齐）</div>
+          <input className="w-full text-black px-2 py-1 rounded" value={syncName} onChange={(e) => setSyncName(e.target.value)} placeholder="你的昵称" />
+          <input className="w-full text-black px-2 py-1 rounded" value={syncRoomId} onChange={(e) => setSyncRoomId(e.target.value)} placeholder="房间ID" />
+          <div className="flex gap-2">
+            <button className="px-2 py-1 rounded bg-blue-500 text-white" onClick={createRoom}>新建</button>
+            <button className="px-2 py-1 rounded bg-emerald-500 text-white" onClick={joinRoom}>加入</button>
+            <button className="px-2 py-1 rounded bg-purple-500 text-white" onClick={syncClock}>校时</button>
+          </div>
+          <div className="flex gap-2">
+            <button className="px-2 py-1 rounded bg-pink-500 text-white" onClick={() => broadcastState(true)}>同步播放</button>
+            <button className="px-2 py-1 rounded bg-gray-500 text-white" onClick={() => broadcastState(false)}>同步暂停</button>
+          </div>
+          <div>{syncInfo}</div>
         </div>
 
         {/* Player Layout - 移动端可滚动 */}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -14,6 +14,23 @@ import { mockApi } from './mock-api';
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api';
 const USE_MOCK_API = false;
 
+interface SyncRoomState {
+  isPlaying: boolean;
+  currentTime: number;
+  songId: string | null;
+  executeAtMs: number;
+  version: number;
+  updatedAtMs: number;
+  actor: string;
+}
+
+interface SyncRoom {
+  id: string;
+  hostName: string;
+  members: string[];
+  state: SyncRoomState;
+}
+
 // Real API Client Configuration
 class RealApiClient {
   private baseURL: string;
@@ -179,6 +196,35 @@ class RealApiClient {
   // Play tracking API
   async recordPlay(songId: string): Promise<ApiResponse<{ songId: string; playCount: number }>> {
     return this.request(`/songs/${songId}/play`, { method: 'POST' });
+  }
+
+  async getSyncTime(): Promise<ApiResponse<{ serverTimeMs: number }>> {
+    return this.request('/sync/time');
+  }
+
+  async createSyncRoom(hostName: string): Promise<ApiResponse<SyncRoom>> {
+    return this.request('/sync/rooms', {
+      method: 'POST',
+      body: JSON.stringify({ hostName }),
+    });
+  }
+
+  async joinSyncRoom(roomId: string, userName: string): Promise<ApiResponse<SyncRoom>> {
+    return this.request(`/sync/rooms/${roomId}/join`, {
+      method: 'POST',
+      body: JSON.stringify({ userName }),
+    });
+  }
+
+  async getSyncRoom(roomId: string): Promise<ApiResponse<SyncRoom>> {
+    return this.request(`/sync/rooms/${roomId}`);
+  }
+
+  async updateSyncRoomAction(roomId: string, payload: Partial<SyncRoomState> & { actor: string; version: number }): Promise<ApiResponse<SyncRoom>> {
+    return this.request(`/sync/rooms/${roomId}/action`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
   }
 }
 

--- a/frontend/src/lib/mock-api.ts
+++ b/frontend/src/lib/mock-api.ts
@@ -20,6 +20,25 @@ import {
 // Mock API delay for realistic experience
 const mockDelay = (ms: number = 300) => new Promise(resolve => setTimeout(resolve, ms));
 
+interface SyncRoomState {
+  isPlaying: boolean;
+  currentTime: number;
+  songId: string | null;
+  executeAtMs: number;
+  version: number;
+  updatedAtMs: number;
+  actor: string;
+}
+
+interface SyncRoom {
+  id: string;
+  hostName: string;
+  members: string[];
+  state: SyncRoomState;
+}
+
+const mockSyncRooms = new Map<string, SyncRoom>();
+
 // Mock API Client
 class MockApiClient {
   // Artists API
@@ -542,6 +561,74 @@ class MockApiClient {
       },
     };
   }
+
+  async getSyncTime(): Promise<ApiResponse<{ serverTimeMs: number }>> {
+    await mockDelay(100);
+    return {
+      success: true,
+      data: { serverTimeMs: Date.now() },
+    };
+  }
+
+  async createSyncRoom(hostName: string): Promise<ApiResponse<SyncRoom>> {
+    await mockDelay();
+    const id = Math.random().toString(36).slice(2, 8).toUpperCase();
+    const now = Date.now();
+    const room: SyncRoom = {
+      id,
+      hostName,
+      members: [hostName],
+      state: {
+        isPlaying: false,
+        currentTime: 0,
+        songId: null,
+        executeAtMs: now,
+        version: 0,
+        updatedAtMs: now,
+        actor: hostName,
+      },
+    };
+    mockSyncRooms.set(id, room);
+    return { success: true, data: room };
+  }
+
+  async joinSyncRoom(roomId: string, userName: string): Promise<ApiResponse<SyncRoom>> {
+    await mockDelay();
+    const room = mockSyncRooms.get(roomId);
+    if (!room) return { success: false, error: 'Room not found' };
+    if (!room.members.includes(userName)) {
+      room.members.push(userName);
+    }
+    return { success: true, data: room };
+  }
+
+  async getSyncRoom(roomId: string): Promise<ApiResponse<SyncRoom>> {
+    await mockDelay(120);
+    const room = mockSyncRooms.get(roomId);
+    if (!room) return { success: false, error: 'Room not found' };
+    return { success: true, data: room };
+  }
+
+  async updateSyncRoomAction(
+    roomId: string,
+    payload: Partial<SyncRoomState> & { actor: string; version: number }
+  ): Promise<ApiResponse<SyncRoom>> {
+    await mockDelay();
+    const room = mockSyncRooms.get(roomId);
+    if (!room) return { success: false, error: 'Room not found' };
+    if (payload.version !== room.state.version) {
+      return { success: false, error: 'Version conflict' };
+    }
+
+    room.state = {
+      ...room.state,
+      ...payload,
+      actor: payload.actor,
+      version: room.state.version + 1,
+      updatedAtMs: Date.now(),
+    };
+    return { success: true, data: room };
+  }
 }
 
 // Export singleton instance for mock API
@@ -575,4 +662,9 @@ export const {
   getHotSongs: mockGetHotSongs,
   getNewSongs: mockGetNewSongs,
   recordPlay: mockRecordPlay,
+  getSyncTime: mockGetSyncTime,
+  createSyncRoom: mockCreateSyncRoom,
+  joinSyncRoom: mockJoinSyncRoom,
+  getSyncRoom: mockGetSyncRoom,
+  updateSyncRoomAction: mockUpdateSyncRoomAction,
 } = mockApi;


### PR DESCRIPTION
### Motivation
- Provide an MVP for multi-device synchronized listening so multiple devices can play the same track in perfect time alignment using a simple server-based clock sync and scheduled execution model. 
- Keep the implementation low-risk and easy to iterate: use in-memory room state and HTTP polling first to validate the UX and timing behavior before investing in a distributed store or WebSocket layer.

### Description
- Add backend sync APIs in `backend/main.py` including `GET /api/sync/time`, `POST /api/sync/rooms`, `POST /api/sync/rooms/{room_id}/join`, `GET /api/sync/rooms/{room_id}`, and `POST /api/sync/rooms/{room_id}/action` to support clock queries, room create/join/query, and scheduled playback actions; rooms are stored in an in-memory `sync_rooms` dict protected by a `Lock`.
- Introduce request models `SyncRoomCreateRequest`, `SyncRoomJoinRequest`, and `SyncRoomActionRequest` for the new endpoints to carry host/user names, playback state, `executeAtMs` and optimistic `version` handling.
- Add frontend API wrappers in `frontend/src/lib/api.ts`: `getSyncTime`, `createSyncRoom`, `joinSyncRoom`, `getSyncRoom`, and `updateSyncRoomAction` with typed `SyncRoom`/`SyncRoomState` interfaces.
- Implement a minimal UI on the Play page in `frontend/src/app/play/play-client.tsx` named “一起听（时间对齐）” that supports nickname, room create/join, clock calibration (`syncClock`), broadcasting scheduled play/pause (`broadcastState`), periodic room polling (1s), and scheduled local apply based on server-aligned `executeAtMs` to achieve time-aligned playback across devices.

### Testing
- Ran frontend lint: `cd frontend && pnpm lint`, which completed successfully (the repository still has unrelated ESLint warnings but no new lint errors from these changes).
- Manual verification steps exercised during development: creating a room, joining a room, clock calibration, broadcasting a play/pause action, and observing that clients schedule local play/pause at the server-aligned `executeAtMs` (behavior implemented via polling and `setTimeout`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a129fd6aa4c8328aa6ee7b878b4dad6)